### PR TITLE
SLING-8483 - Added Priority to the Extension Handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.feature.launcher</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.7-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/feature/extension/content/ContentHandler.java
+++ b/src/main/java/org/apache/sling/feature/extension/content/ContentHandler.java
@@ -105,6 +105,11 @@ public class ContentHandler implements ExtensionHandler {
     }
 
     @Override
+    public int getPriority() {
+        return 100;
+    }
+
+    @Override
     public boolean handle(ExtensionContext context, Extension extension) throws Exception {
         File registryHome = getRegistryHomeDir(context);
         if (extension.getType() == ExtensionType.ARTIFACTS


### PR DESCRIPTION
This will provide the Extension Handler Priority to make EH sortable and not rely on Classloading order
This PR depends on this PR: https://github.com/apache/sling-org-apache-sling-feature-launcher/pull/13