### PR TITLE
SLING-12568 - Content extension advertises services for shaded and relocated packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,26 @@
                                     <exclude>org.slf4j:*</exclude>
                                 </excludes>
                             </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.jackrabbit.vault:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.jackrabbit:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.fasterxml.woodstox:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/services/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <relocations>
                                 <!-- shade and relocate all "compile" scope dependencies (which are not coming with the launcher) -->
                                 <relocation>


### PR DESCRIPTION
Exclude META-INF/services files from dependencies that have them. With this change only the org.apache.sling.feature.launcher.spi.extensions.ExtensionHandler is advertised.